### PR TITLE
colon_on/1, colon_off/1, colon_on_all/1, colon_off_all/1

### DIFF
--- a/lib/ht16k33_multi.ex
+++ b/lib/ht16k33_multi.ex
@@ -388,6 +388,74 @@ defmodule Ht16k33Multi do
     devices_names |> Enum.map(fn device -> Ht16k33Multi.dimming(value, device) end)
   end
 
+  @doc """
+  Sets colon on for the 7-segment display.
+
+    * `name` – The GenServer name of the device.
+      This should match the name provided to `Ht16k33Multi.start_link/1`,
+      e.g., `Ht16k33Multi.start_link(name: :red_leds)`.
+
+  ## Examples
+
+      Ht16k33Multi.colon_on(:red_leds)
+  """
+  @doc since: "0.2.0"
+  @spec colon_on(atom() | pid() | {atom(), any()} | {:via, atom(), any()}) :: :ok
+  def colon_on(name \\ __MODULE__), do: GenServer.cast(name, :colon_on)
+
+  @doc """
+  Sets colon on for all displays.
+
+    * `devices_names` – A list of GenServer names that identify the displays.
+      These names should match those provided to `Ht16k33Multi.start_link/1`,
+      e.g., `[:blue_leds, :red_leds]`.
+
+  This function calls `colon_on/1` for each device in the list,
+  setting the colon on for all of them.
+
+  ## Examples
+
+      Ht16k33Multi.colon_on_all([:blue_leds, :red_leds])
+  """
+  @doc since: "0.2.0"
+  @spec colon_on_all(any()) :: list()
+  def colon_on_all(devices_names),
+    do: devices_names |> Enum.map(fn device -> Ht16k33Multi.colon_on(device) end)
+
+  @doc """
+  Sets colon off for the 7-segment display.
+
+    * `name` – The GenServer name of the device.
+      This should match the name provided to `Ht16k33Multi.start_link/1`,
+      e.g., `Ht16k33Multi.start_link(name: :red_leds)`.
+
+  ## Examples
+
+      Ht16k33Multi.colon_off(:red_leds)
+  """
+  @doc since: "0.2.0"
+  @spec colon_off(atom() | pid() | {atom(), any()} | {:via, atom(), any()}) :: :ok
+  def colon_off(name \\ __MODULE__), do: GenServer.cast(name, :colon_off)
+
+  @doc """
+  Sets colon off for all displays.
+
+    * `devices_names` – A list of GenServer names that identify the displays.
+      These names should match those provided to `Ht16k33Multi.start_link/1`,
+      e.g., `[:blue_leds, :red_leds]`.
+
+  This function calls `colon_off/1` for each device in the list,
+  setting the colon off for all of them.
+
+  ## Examples
+
+      Ht16k33Multi.colon_off_all([:blue_leds, :red_leds])
+  """
+  @doc since: "0.2.0"
+  @spec colon_off_all(any()) :: list()
+  def colon_off_all(devices_names),
+    do: devices_names |> Enum.map(fn device -> Ht16k33Multi.colon_off(device) end)
+
   # server callbacks
 
   @impl true
@@ -418,4 +486,12 @@ defmodule Ht16k33Multi do
   @impl true
   def handle_cast({:dimming, value}, %__MODULE__{} = ht16k33),
     do: {:noreply, Display.Dimming.set(value) |> I2cBus.write(ht16k33)}
+
+  @impl true
+  def handle_cast(:colon_on, %__MODULE__{} = ht16k33),
+    do: {:noreply, Display.colon_on() |> I2cBus.write(ht16k33)}
+
+  @impl true
+  def handle_cast(:colon_off, %__MODULE__{} = ht16k33),
+    do: {:noreply, Display.colon_off() |> I2cBus.write(ht16k33)}
 end

--- a/lib/ht16k33_multi/display.ex
+++ b/lib/ht16k33_multi/display.ex
@@ -89,7 +89,7 @@ defmodule Ht16k33Multi.Display do
   """
   @doc since: "0.1.0"
   @spec colon_on() :: <<_::16>>
-  def colon_on(), do: <<@colon_position, 0x01>>
+  def colon_on(), do: <<@colon_position, 0x02>>
 
   @doc """
   Command to turn the colon off.

--- a/test/ht16k33_multi_test.exs
+++ b/test/ht16k33_multi_test.exs
@@ -225,4 +225,56 @@ defmodule Ht16k33MultiTest do
       assert Ht16k33Multi.blinking_off_all(devices) == [:ok, :ok, :ok]
     end
   end
+
+  describe "colon_on/1" do
+    test "colon on command succeeds" do
+      address = 0x72
+      start_supervised({Ht16k33Multi, name: :green_leds, address: address})
+      Ht16k33Multi.colon_on(:green_leds)
+
+      assert %Ht16k33Multi{
+               name: :green_leds,
+               last_command: %I2cBus{command: <<0x04, 0x02>>, exit_status: :ok}
+             } = :sys.get_state(:green_leds)
+    end
+  end
+
+  describe "colon_off/1" do
+    test "colon off command succeeds" do
+      address = 0x72
+      start_supervised({Ht16k33Multi, name: :green_leds, address: address})
+      Ht16k33Multi.colon_off(:green_leds)
+
+      assert %Ht16k33Multi{
+               name: :green_leds,
+               last_command: %I2cBus{command: <<0x04, 0x00>>, exit_status: :ok}
+             } = :sys.get_state(:green_leds)
+    end
+  end
+
+  describe "colon_on_all/1" do
+    test "write to three displays and set colon on for all" do
+      devices = [:red, :green, :blue]
+      devices_address = [red: 0x70, green: 0x71, blue: 0x72]
+
+      for {device, address} <- devices_address do
+        start_supervised({Ht16k33Multi, name: device, address: address})
+      end
+
+      assert Ht16k33Multi.colon_on_all(devices) == [:ok, :ok, :ok]
+    end
+  end
+
+  describe "colon_off_all/1" do
+    test "write to three displays and set colon off for all" do
+      devices = [:red, :green, :blue]
+      devices_address = [red: 0x70, green: 0x71, blue: 0x72]
+
+      for {device, address} <- devices_address do
+        start_supervised({Ht16k33Multi, name: device, address: address})
+      end
+
+      assert Ht16k33Multi.colon_off_all(devices) == [:ok, :ok, :ok]
+    end
+  end
 end

--- a/test/ht16k33_multi_test/display_test.exs
+++ b/test/ht16k33_multi_test/display_test.exs
@@ -11,7 +11,7 @@ defmodule Ht16k33MultiTest.DisplayTest do
 
   describe "colon_on/0" do
     test "colon on command" do
-      assert Display.colon_on() == <<0x04, 0x01>>
+      assert Display.colon_on() == <<0x04, 0x02>>
     end
   end
 

--- a/test/ht16k33_multi_test/multidevice_test.exs
+++ b/test/ht16k33_multi_test/multidevice_test.exs
@@ -19,9 +19,7 @@ defmodule Ht16k33MultiTest.MultiDevicesTest do
       characters = "characters for all devices"
       devices = [:red, :green, :blue]
 
-      assert MultiDevices.split_for_devices(characters, devices,
-               one_word_per_display: false
-             ) == [
+      assert MultiDevices.split_for_devices(characters, devices, one_word_per_display: false) == [
                red: "char",
                green: "acte",
                blue: "rs f"
@@ -29,12 +27,11 @@ defmodule Ht16k33MultiTest.MultiDevicesTest do
     end
 
     test "German >Umlaute< (ä, ö, ü) are displayed correct in a word" do
-      assert MultiDevices.split_for_devices("hübsch", [:red, :blue],
-               one_word_per_display: false
-             ) == [
-               red: "hübs",
-               blue: "ch"
-             ]
+      assert MultiDevices.split_for_devices("hübsch", [:red, :blue], one_word_per_display: false) ==
+               [
+                 red: "hübs",
+                 blue: "ch"
+               ]
     end
 
     test "write spaces to the appended devices that are not used" do


### PR DESCRIPTION
This pull request adds functions to control the colon indicator on 7-segment displays via GenServer calls: `colon_on/1`, `colon_off/1`, `colon_on_all/1`, and `colon_off_all/1`. These functions allow enabling or disabling the colon for individual or multiple devices started with `Ht16k33Multi.start_link/1`.