### PR TITLE
Ht16k33Multi.init() clears all segments

### DIFF
--- a/lib/ht16k33_multi/display.ex
+++ b/lib/ht16k33_multi/display.ex
@@ -58,13 +58,13 @@ defmodule Ht16k33Multi.Display do
 
   @doc """
   Initialize the display by enabling the oscillation, turning the display on,
-  and ensuring the colon is off for a clean display of text.
+  and ensuring the colon and all LED segments are off for a clean display of text.
 
   This is required to begin displaying something on the `Ht16k33`.
   """
   @doc since: "0.1.0"
   @spec initialize() :: [<<_::16>> | 33 | 129, ...]
-  def initialize(), do: [oscillation_on(), display_on(), colon_off()]
+  def initialize(), do: [oscillation_on(), display_on(), clear()]
 
   @doc """
   Command to start the oscillation, which is necessary for initialization.

--- a/test/ht16k33_multi_test.exs
+++ b/test/ht16k33_multi_test.exs
@@ -42,6 +42,20 @@ defmodule Ht16k33MultiTest do
     end
   end
 
+  describe "init/1" do
+    test "when GenServer initilizes it clears the display" do
+      address = 0x71
+      start_supervised({Ht16k33Multi, name: :blue_leds, address: address})
+
+      # cf. Ht16k33.Display.clear/0
+      clear_command = <<0, 0, 2, 0, 6, 0, 8, 0, 4, 0>>
+
+      assert %Ht16k33Multi{last_command: last_command} = :sys.get_state(:blue_leds)
+      assert %I2cBus{command: command} = last_command
+      assert clear_command == command
+    end
+  end
+
   describe "status/1" do
     test "gets the status for different GenServer names" do
       address = 0x70

--- a/test/ht16k33_multi_test/display_test.exs
+++ b/test/ht16k33_multi_test/display_test.exs
@@ -3,6 +3,16 @@ defmodule Ht16k33MultiTest.DisplayTest do
 
   alias Ht16k33Multi.Display
 
+  describe "initialize/0" do
+    test "turns on oscillation and clears all segments command" do
+      oscillation = 0x21
+      display_on = 0x81
+      clear_command = <<0, 0, 2, 0, 6, 0, 8, 0, 4, 0>>
+
+      assert Display.initialize() == [oscillation, display_on, clear_command]
+    end
+  end
+
   describe "oscillation_on/0" do
     test "oscillation_on command" do
       assert Display.oscillation_on() == 0x21


### PR DESCRIPTION
Fixes issue Ht16k33Multi.init/0 does not clear all LED segments upon initialization. #2